### PR TITLE
fix: shebang in list-all

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -Eo pipefail
 


### PR DESCRIPTION
The shebang in the list-all script uses an absolute path instead of `/usr/bin/env`. This means it doesn't work in all environments (e.g. when using NixOS). This change also makes it consistent with the install command.

For reference, here's the error I was getting before fixing this:

```shell
$ asdf list-all zig
Plugin zig's list-all callback script failed with output:
/nix/store/6fas7yys5cqaaz3p52ki3nzgymr3jb2l-asdf-vm-0.14.1/share/asdf-vm/lib/functions/versions.bash: line 98: /home/adamc/.asdf/plugins/zig/bin/list-all: cannot execute: required file not found
```