### PR TITLE
Add warning about ZLS master

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -161,6 +161,12 @@ def download(version, zig_outfile, zls_outfile):
     tarball_info = links[link_key]
     download_tarball(zig_outfile, tarball_info)
 
+    if version == 'master':
+        logging.warning(
+            'ZLS is not available for Zig master. You will need to build ZLS from source. See: https://github.com/zigtools/zls'
+        )
+        return
+
     try:
         zls_links = query_zls(version)
         if link_key not in zls_links:


### PR DESCRIPTION
When installing zig master `asdf install zig master` it fails to install `zls` because there is no pre-built version for `zls`
```
curl -q https://releases.zigtools.org/v1/zls/select-version?zig_version=master&compatibility=full
{"error":"Query component 'zig_version' with value 'master' is not a valid version!"}
```

This adds a warning to point people towards the official `zls` repository.