### PR TITLE
feat: support custom zig versions and master builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,36 @@ zls version
 Check [asdf](https://github.com/asdf-vm/asdf) readme for more instructions on how to
 install & manage versions.
 
+# Custom Versions
+
+This plugin supports installing custom zig versions that are not in the official release index.
+
+## Why?
+
+The official `asdf-zig` can only support versions listed at `https://ziglang.org/download/index.json`. But zig evolves fast, and sometimes you need to stick with a specific dev version like `0.12.0-dev.2139+e025ad7b4`.
+
+## How to use custom versions
+
+1. Create the custom versions directory and file:
+
+```bash
+mkdir -p ~/.asdf/custom/zig
+echo '{"0.12.0-dev.2139+e025ad7b4": {}, "0.12.0-dev.1828+225fe6ddb": {}}' > ~/.asdf/custom/zig/versions.json
+```
+
+2. Your custom versions will now appear in `asdf list all zig` and can be installed with `asdf install zig <version>`.
+
+## Installing master version
+
+You can also install the current master version of zig:
+
+```bash
+asdf list all zig  # Shows master_<version> at the end
+asdf install zig master_<version>
+```
+
+The master version is prefixed with `master_` to distinguish it from release versions.
+
 # License
 
 [Apache License 2.0](LICENSE)

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -203,7 +203,6 @@ def download(version, zig_outfile, zls_outfile):
             url = f'https://ziglang.org/builds/zig-{os_name}-{arch}-{version}.tar.xz'
             logging.info(f'Downloading custom version {version} from {url}')
             # For custom versions, we don't have shasum, so we skip verification
-            import tempfile
             # Download without shasum verification
             try:
                 req = urllib.request.Request(url, headers={'User-Agent': USER_AGENT})

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -15,6 +15,7 @@ import logging
 INDEX_URL = os.getenv('ASDF_ZIG_INDEX_URL', 'https://ziglang.org/download/index.json')
 HTTP_TIMEOUT = int(os.getenv('ASDF_ZIG_HTTP_TIMEOUT', '30'))
 USER_AGENT = 'asdf-zig (https://github.com/asdf-community/asdf-zig)'
+CUSTOM_VERSIONS_PATH = os.path.expanduser('~/.asdf/custom/zig/versions.json')
 
 # https://ziglang.org/download/community-mirrors.txt
 # If any of these mirrors are down, please open an issue!
@@ -88,10 +89,30 @@ def query_zls(zig_version):
         return json.loads(body)
 
 
+def load_custom_versions():
+    """Load custom versions from ~/.asdf/custom/zig/versions.json"""
+    if not os.path.exists(CUSTOM_VERSIONS_PATH):
+        return []
+    try:
+        with open(CUSTOM_VERSIONS_PATH, 'r') as f:
+            custom = json.load(f)
+        return list(custom.keys())
+    except Exception as e:
+        logging.warning(f'Failed to load custom versions from {CUSTOM_VERSIONS_PATH}: {e}')
+        return []
+
+
 def all_versions():
     index = fetch_index()
     versions = [k for k in index.keys() if k != 'master']
     versions.sort(key=lambda v: tuple(map(int, v.split('.'))))
+    # Add master version with prefix
+    if 'master' in index:
+        master_version = index['master'].get('version', 'master')
+        versions.append(f'master_{master_version}')
+    # Add custom versions
+    custom_versions = load_custom_versions()
+    versions.extend(custom_versions)
     return versions
 
 
@@ -166,7 +187,36 @@ def download(version, zig_outfile, zls_outfile):
         versions = list(k for k in index.keys() if k != 'master')
         versions.sort(key=lambda v: tuple(map(int, v.split('.'))))
         version = versions[-1]
+    # Handle master_ prefixed versions
+    if version.startswith('master_'):
+        version = 'master'
+    # Handle custom versions - construct download URL from version string
     if version not in index:
+        # Check if this is a custom version (dev version format)
+        # Try to construct the URL: https://ziglang.org/builds/zig-{os}-{arch}-{version}.tar.xz
+        custom_versions = load_custom_versions()
+        if version in custom_versions:
+            os_name = platform.system().lower()
+            arch = platform.machine().lower()
+            os_name = OS_MAPPING.get(os_name, os_name)
+            arch = ARCH_MAPPING.get(arch, arch)
+            url = f'https://ziglang.org/builds/zig-{os_name}-{arch}-{version}.tar.xz'
+            logging.info(f'Downloading custom version {version} from {url}')
+            # For custom versions, we don't have shasum, so we skip verification
+            import tempfile
+            # Download without shasum verification
+            try:
+                req = urllib.request.Request(url, headers={'User-Agent': USER_AGENT})
+                with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as response:
+                    with open(zig_outfile, 'wb') as f:
+                        while True:
+                            chunk = response.read(1024 * 1024)
+                            if not chunk:
+                                break
+                            f.write(chunk)
+                return
+            except Exception as e:
+                raise Exception(f'Failed to download custom version {version}: {e}')
         raise Exception(f'There is no such version: {version}')
 
     links = index[version]


### PR DESCRIPTION
- Add load_custom_versions() to read from ~/.asdf/custom/zig/versions.json
- Include master_<version> in list-all output for zig master builds
- Handle master_ prefix in download to map to 'master' index entry
- Support downloading custom dev versions from ziglang.org/builds/
- Update README with custom version usage instructions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for installing custom Zig dev versions and master builds, so users can pin non-official builds like `0.12.0-dev.2139+e025ad7b4`.

- Reads custom versions from `~/.asdf/custom/zig/versions.json` and shows them in `asdf list all zig`.
- Lists `master_<version>` for the current master build and maps it back to the `master` index entry when downloading.
- Skips shasum verification for custom versions since no checksum is available.
- Documents custom version setup and master installation in the README.

<sup>Written for commit f2fdf2813ed2056b2b3cd4835e5f3d2f9a40e260. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/asdf-community/asdf-zig/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

